### PR TITLE
Update homepage resume sections and remove recent blog post

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,8 +38,8 @@
                     <span class="corner bottom-right"></span>
                 </div>
                 <h1>
-                    "A job is not finished until 
-                    <span class="highlight-text">nobody can tell</span> 
+                    "A job is not finished until
+                    <span class="highlight-text">nobody can tell</span>
                     that you were ever there."
                 </h1>
             </div>
@@ -82,9 +82,9 @@
                             </div>
                         </div>
                     </div>
-                
+
                 </div>
-                
+
                 <div class="experience-item">
                     <div class="experience-header">
                         <div class="experience-logo-title">
@@ -98,7 +98,7 @@
                             </div>
                         </div>
                     </div>
-                 
+
                 </div>
 
                 <div class="experience-item">
@@ -114,7 +114,20 @@
                             </div>
                         </div>
                     </div>
-                
+
+                </div>
+
+                <div class="experience-item">
+                    <div class="experience-header">
+                        <div class="experience-logo-title">
+                            <div>
+                                <h3>AI Operations &amp; Automation Intern — SRE Reliability</h3>
+                                <span class="company">Siemens</span>
+                                <span class="duration">Mar 2026 - Present</span>
+                            </div>
+                        </div>
+                    </div>
+
                 </div>
             </div>
         </section>
@@ -155,6 +168,18 @@
                     <p class="education-description">
                         Merit-based exchange scholarship recipient
                     </p>
+                </div>
+                <div class="education-item">
+                    <div class="education-header">
+                        <div class="education-logo-title">
+                            <div>
+                                <h3>Ensimag Grenoble INP</h3>
+                                <span class="education-year">Sept 2025 - Present</span>
+                            </div>
+                        </div>
+                    </div>
+                    <p class="education-degree">Master’s in Applied Artificial Intelligence</p>
+                    <p class="education-description">Grenoble, France</p>
                 </div>
             </div>
         </section>
@@ -211,32 +236,10 @@
                         <span>devops</span>
                     </div>
                 </div>
-                
+
             </div>
         </section>
 
-        <section class="recent-posts">
-            <h2>Recent Blog Posts</h2>
-            <div class="post-grid">
-                <article class="post-card">
-                    <div class="post-meta">
-                        <time datetime="2024-03-20">March 20, 2024</time>
-                        <span class="reading-time">5 min read</span>
-                    </div>
-                    <h3>
-                        <a href="blog/getting-mistral-api-key.html">How to Get a Free Mistral AI Hobbyist API Key</a>
-                    </h3>
-                    <p>A comprehensive guide to getting started with Mistral AI's free tier and building AI-powered applications.</p>
-                    <div class="post-tags">
-                        <span>AI</span>
-                        <span>Tutorial</span>
-                        <span>API</span>
-                    </div>
-                </article>
-
-            </div>
-            <a href="blog.html" class="view-all">View All Posts →</a>
-        </section>
     </main>
 </body>
-</html> 
+</html>


### PR DESCRIPTION
### Motivation
- Update the homepage resume to reflect the latest education and role and remove the inline blog highlight to keep the landing page focused on the portfolio.

### Description
- Added an Experience entry for "AI Operations & Automation Intern — SRE Reliability" at "Siemens" with dates `Mar 2026 - Present` in `index.html`.
- Added an Education entry for "Ensimag Grenoble INP" with `Master’s in Applied Artificial Intelligence`, location "Grenoble, France", dates `Sept 2025 - Present` in `index.html`.
- Removed the homepage "Recent Blog Posts" section that contained the Mistral API post by deleting the corresponding article block in `index.html`.
- Cleaned up trailing whitespace in `index.html` and committed the consolidated changes.

### Testing
- Ran `git diff --check` to verify there are no remaining whitespace issues and it passed.
- Executed a small automated whitespace cleanup script (`python` one-liner) to normalize line endings and trailing spaces and it completed successfully.
- Verified `git status` and committed the updated `index.html` file successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbda5f3a0c832c8019d616ac7d02d6)